### PR TITLE
Correct description for ETC extension.

### DIFF
--- a/src/views/extensions/info.coffee
+++ b/src/views/extensions/info.coffee
@@ -175,7 +175,7 @@ exports.index =
         versions: [1,2]
     WEBGL_compressed_texture_etc:
         description: '''
-            Offers compressed texture format support for <a href="https://en.wikipedia.org/wiki/Ericsson_Texture_Compression">ETC1</a>.
+            Offers compressed texture format support for <a href="https://en.wikipedia.org/wiki/Ericsson_Texture_Compression">ETC2 and EAC</a>.
         '''
         status: 'community'
         versions: [1,2]


### PR DESCRIPTION
WEBGL_compressed_texture_etc extension had incorrect description referring to ETC1 instead of ETC2 and EAC.